### PR TITLE
Added version checker, auto packager and auto release maker

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -1,0 +1,71 @@
+name: Auto NIC packager
+
+# On every push
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - "template/*"
+
+jobs:
+  packager:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      env:
+        VERSION: ""
+    - name: Install Theos
+      run: |
+        sudo apt-get install fakeroot git perl clang-6.0 build-essential -y
+        echo "export THEOS=~/theos" >> ~/.profile
+        source ~/.profile
+        git clone --recursive https://github.com/theos/theos.git $THEOS
+        
+        curl https://kabiroberai.com/toolchain/download.php?toolchain=ios-linux -Lo toolchain.tar.gz
+        tar xzf toolchain.tar.gz -C $THEOS/toolchain
+        rm toolchain.tar.gz
+        
+        curl -LO https://github.com/theos/sdks/archive/master.zip
+        TMP=$(mktemp -d)
+        unzip master.zip -d $TMP
+        mv $TMP/sdks-master/*.sdk $THEOS/sdks
+        rm -r master.zip $TMP
+      
+    - name: Get version
+      run: echo ::set-env name=VERSION::$(cat ./template/versionCheck.sh | sed -n 2p | tail -c 7 | head -c 5)
+
+    - name: Make NIC package
+      run: |
+        source ~/.profile
+        rm ./iOS-Mod-Menu-Template-for-Theos.nic.tar || true # To force it to not fail even if the file does not exist
+        $THEOS/bin/nicify.pl ./template
+        
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: "Ted2's Mod Menu Template.nic.tar"
+        path: "./Ted2's Mod Menu Template.nic.tar"
+        
+    - name: Create Release
+      id: create-release
+      uses: actions/create-release@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.VERSION }}
+        release_name: Release ${{ env.VERSION }}
+        body: ""
+        draft: false
+        prerelease: false
+    
+    - name: Add Package to release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create-release.outputs.upload_url }}
+        asset_path: "./Ted2's Mod Menu Template.nic.tar"
+        asset_name: "Ted2-Mod-Menu-Template.nic.tar"
+        asset_content_type: application/x-tar
+          

--- a/template/Makefile
+++ b/template/Makefile
@@ -57,5 +57,8 @@ endif
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 
+internal-package-check::
+	@./versionCheck.sh # Script to verify template's current version
+
 after-install::
 	install.exec "killall -9 @@BINARYNAME@@ || :"

--- a/template/versionCheck.sh
+++ b/template/versionCheck.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+VERSION='0.5.0'
+
+ERROR='\033[1;31m[*] Error:\033[1;37m '
+SUCCESS='\033[1;32m==>\033[1;37m '
+
+# Check if user has both commands curl and sed, if not tell them to install them for this functionality
+if ! [ -x "$(command -v curl)" ]; then
+	echo -e "${ERROR}You must install curl for the version check to work"
+	exit 0 # Exit 0 since this is not critical. (Allows compilation to continue)
+fi
+
+if ! [ -x "$(command -v sed)" ]; then
+	echo -e "${ERROR}You must install sed for the version check to work"
+	exit 0 # Exit 0 since this is not critical. (Allows compilation to continue)
+fi
+
+if ! [ $(curl -Ls https://github.com/bR34Kr/iOS-Mod-Menu-Template-for-Theos/raw/master/template/Macros.h | sed -n 2p) = "VERSION='$VERSION'"  ]; then
+	echo -e "${SUCCESS}A newer version is available!"
+fi

--- a/template/versionCheck.sh
+++ b/template/versionCheck.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 VERSION='0.5.0'
+# Don't remove the above line. Serves as the version this script will fetch. Only update when a new version is out.
 
 ERROR='\033[1;31m[*] Error:\033[1;37m '
 SUCCESS='\033[1;32m==>\033[1;37m '
@@ -15,6 +16,14 @@ if ! [ -x "$(command -v sed)" ]; then
 	exit 0 # Exit 0 since this is not critical. (Allows compilation to continue)
 fi
 
-if ! [ $(curl -Ls https://github.com/bR34Kr/iOS-Mod-Menu-Template-for-Theos/raw/master/template/Macros.h | sed -n 2p) = "VERSION='$VERSION'"  ]; then
-	echo -e "${SUCCESS}A newer version is available!"
+# Check if GitHub is reachable
+curl -s https://github.com > /dev/null
+githubReachable=$?
+
+if ! [ $githubReachable == 0  ]; then
+	exit 0
+fi
+
+if ! [ $(curl -Ls https://github.com/joeyjurjens/iOS-Mod-Menu-Template-for-Theos/raw/master/template/versionCheck.sh | sed -n 2p) = "VERSION='$VERSION'"  ]; then
+	echo -e "${SUCCESS}A newer version of the template is available!"
 fi


### PR DESCRIPTION
New features with this implementation:
- Version checker so developers using it can know when it's time to update
  - Works without internet connectivity (by not doing anything)
  - Purely acts as a notification system, so it won't affect compilation whatsoever
- Auto packager (removes the nicify.pl fuss)
- Auto release maker
- Only creates new packages and releases when changes are made in /template of the master branch

Flaws of the current implementation:
- You **must** change the version in [/template/versionCheck.sh on line 2](https://github.com/bR34Kr/iOS-Mod-Menu-Template-for-Theos/blob/dc737319de9ed0bd03dbca6b83412856ccae030a/template/versionCheck.sh#L2) in **each** commit to not have errors while creating new releases
- Version changing is not the most user-friendly
- Version checking might be excessive when doing a lot of compilations